### PR TITLE
404 page is missing styling.

### DIFF
--- a/ndohyep/templates/_404.html
+++ b/ndohyep/templates/_404.html
@@ -5,8 +5,9 @@
 {% block body_class %}template-404{% endblock %}
 
 {% block content %}
-    <h1>{% trans "Page not found" %}</h1>
-
-    <h2>{% trans "Sorry, this page could not be found." %}</h2>
+<div class="block grey join">
+    <h2>{% trans "Page not found" %}</h2>
+    <h1>{% trans "Sorry, this page could not be found." %}</h1>
+    <p></p>
+</div>
 {% endblock %}
-


### PR DESCRIPTION
https://b-wise.mobi/english/mind-blowing/toxic-energiser/ as an example.
