### PR TITLE
Add a paginated view of all comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,5 @@ local.py
 db.sqlite3
 docs/_build
 .DS_Store
-static/
+
 media/

--- a/app/views.py
+++ b/app/views.py
@@ -21,6 +21,7 @@ from wagtail.wagtailsearch.models import Query
 import django_comments
 
 from molo.commenting.forms import MoloCommentForm
+from molo.commenting.models import MoloComment
 
 
 @csrf_protect
@@ -135,4 +136,12 @@ def search(request, results_per_page=10):
         'search_query': search_query,
         'search_results': search_results,
         'results': results,
+    })
+
+
+def report_response(request, comment_pk):
+    comment = MoloComment.objects.get(pk=comment_pk)
+
+    return render(request, 'comments/report_response.html', {
+        'article': comment.content_object,
     })

--- a/ndohyep/static/css/smart.css
+++ b/ndohyep/static/css/smart.css
@@ -204,10 +204,11 @@ textarea {width:94%; font-size:100%; padding:10px; display:block; background:whi
 	.post-comment a {font-weight:700; text-transform:uppercase; }
 	.post-comment .anon {color:white; margin-left:10px; padding:8px 12px; display:inline-block; font-weight:700; color:#13212f; text-transform:uppercase; background:white; background:rgba(255,255,255,0.6); text-decoration:none;}
 .comments-count {text-decoration:none; color:#20364d !important; display:inline-block; float:right; vertical-align:middle; height:30px; line-height:25px; width:25px; text-align:center; padding-right:2px; background:url(../img/comments-count.png) 0 0 no-repeat;  background-size:100%; color:#20364d; font-size:70%;}
-.comment {font-weight:normal; border-bottom:1px solid rgba(255,255,255,0.5); padding:20px 20px 0; width:100%; margin:0 -20px;}
-	.comment .by {font-weight:700; text-transform:uppercase; }
+.comment {font-weight:normal; border-bottom:1px solid rgba(255,255,255,0.5); padding:20px; width:100%; margin:0 -20px;}
+	.comment .by {font-weight:700; text-transform:uppercase; padding:0 0 5px;}
 		.comment .by .date {color:white; font-weight:normal; font-style:italic; padding:0 0 0 10px;}
-	.comment .report {color:white; font-weight:700; text-transform:uppercase;}
+	.comment .report {color:white; font-weight:700; text-transform:uppercase; padding:0 0 5px;}
+	.comment p {padding:0 0 10px;}
 .comment.expert {font-weight: bold;}
 	.comment.expert p.by {background:url('../img/star_icon_small.png') 0 0 no-repeat; padding: 5px 30px 10px;}
 

--- a/ndohyep/static/css/styles.css
+++ b/ndohyep/static/css/styles.css
@@ -30,10 +30,11 @@ img {max-width:100%;}
 
 
 /* Footer */
-.footer {padding:20px 0; font-size:75%; font-weight:normal; clear:both; display:block;}
+.footer {padding:20px 0; font-size:75%; font-weight:normal; clear:both; display:block; border-top: 1px solid #d7dde3;}
 	.footer p {padding:5px 20px; color:#b8bfc6;}
    .footer img {max-width:66%;}
 	.footer a {color:#b8bfc6; text-decoration:underline; padding:0 8px 0 2px;}
 	.footer a:hover, .footer a:active {color:#f36c40;}
 
-.pagination {padding:15px 0; text-align: left}
+.pagination {padding:15px 0; text-align: left; }
+.pagination a {text-decoration: none;}

--- a/ndohyep/static/css/styles.css
+++ b/ndohyep/static/css/styles.css
@@ -32,6 +32,8 @@ img {max-width:100%;}
 /* Footer */
 .footer {padding:20px 0; font-size:75%; font-weight:normal; clear:both; display:block;}
 	.footer p {padding:5px 20px; color:#b8bfc6;}
-   .footer img {max-width:66%;}     
+   .footer img {max-width:66%;}
 	.footer a {color:#b8bfc6; text-decoration:underline; padding:0 8px 0 2px;}
 	.footer a:hover, .footer a:active {color:#f36c40;}
+
+.pagination {padding:15px 0; text-align: left}

--- a/ndohyep/templates/comments/comment.html
+++ b/ndohyep/templates/comments/comment.html
@@ -1,12 +1,12 @@
-{% load i18n humanize ndohyep_tags %}
+{% load i18n humanize ndohyep_tags molo_commenting_tags %}
 <div class="comment {% if node.user|is_in_group:'Experts' %}expert{% endif %}">
-  <p class="by">{{node.user_name}} <span class="date">{{node.submit_date|naturaltime}}</span></p>
+  <p class="by">{{node.user_name}}<span class="date">{{node.submit_date|naturaltime}}</span></p>
   <p>{{node.comment}}</p>
   {% if not node.user|is_in_group:'Experts' %}
-    <p><a href="{% url 'molo-comments-report' node.pk %}" class="report">{% trans "Report"%} +</a></p>
+    <p><a href="{% url 'molo-comments-report' node.pk %}?next={% url 'report_response' node.pk %}" class="report">{% trans "Report"%}</a></p>
   {% endif %}
   {% if request.user|is_in_group:'Experts' and not node.user|is_in_group:'Experts' %}
-    <p><a href="{% url 'comments-reply' node.pk %}" class="report">{% trans "Reply"%} +</a></p>
+    <p><a href="{% url 'comments-reply' node.pk %}" class="report">{% trans "Reply"%}</a></p>
   {% endif %}
 </div><!-- /comment -->
 {% for child in node.get_children %}

--- a/ndohyep/templates/comments/comments.html
+++ b/ndohyep/templates/comments/comments.html
@@ -5,7 +5,7 @@
 <div class="title {{self.articlepage.get_parent_section.get_effective_extra_style_hints}}">
 <h5>{% trans "Comments" %}</h5>
 </div>
-<div class="block {{self.articlepage.get_parent_section.get_effective_extra_style_hints}}">
+<div class="block {{self.articlepage.get_parent_section.get_effective_extra_style_hints}}" id="comments-list">
       {% for node in comments %}
         {% include "comments/comment.html" %}
       {% endfor %}

--- a/ndohyep/templates/comments/comments.html
+++ b/ndohyep/templates/comments/comments.html
@@ -1,0 +1,31 @@
+{% extends "core/_article_page.html" %}
+{% load wagtailcore_tags wagtailimages_tags comments mptt_tags molo_commenting_tags i18n %}
+
+{% block content %}
+<div class="title {{self.articlepage.get_parent_section.get_effective_extra_style_hints}}">
+<h5>{% trans "Comments" %}</h5>
+</div>
+<div class="block {{self.articlepage.get_parent_section.get_effective_extra_style_hints}}">
+      {% for node in comments %}
+        {% include "comments/comment.html" %}
+      {% endfor %}
+
+<div class="pagination">
+    <span class="step-links">
+        {% if comments.has_previous %}
+            <a href="?p={{ comments.previous_page_number }}">&larr;</a>
+        {% endif %}
+        <span class="current">
+            Page {{ comments.number }} of {{ comments.paginator.num_pages }}
+        </span>
+        {% if comments.has_next %}
+            <a href="?p={{ comments.next_page_number }}">&rarr;</a>
+        {% endif %}
+    </span>
+    <br>
+    <br>
+    <a href="{% pageurl self %}">{% trans "Back to article" %}</a>
+</div>
+
+</div>
+{% endblock %}

--- a/ndohyep/templates/comments/form.html
+++ b/ndohyep/templates/comments/form.html
@@ -1,10 +1,10 @@
 {% load comments i18n wagtailcore_tags wagtailimages_tags %}
 
-<form action="{% url 'molo-comments-post' %}" method="post">
+<form action="{% url 'molo-comments-post' %}#comments-list" method="post">
     {% csrf_token %}
     {% if form.errors %}
-      <h4>{% blocktrans count counter=form.errors|length %}Please correct the error below{% plural %}Please correct the
-        errors below{% endblocktrans %}</h4>
+      <h4>{% blocktrans count counter=form.errors|length %}{% trans "Please correct the error below" %}{% plural %}{% trans "Please correct the
+        errors below" %}{% endblocktrans %}</h4>
     {% endif %}
 
     {% if form.comment.errors %}{{ form.comment.errors }}{% endif %}

--- a/ndohyep/templates/comments/form.html
+++ b/ndohyep/templates/comments/form.html
@@ -3,8 +3,8 @@
 <form action="{% url 'molo-comments-post' %}#comments-list" method="post">
     {% csrf_token %}
     {% if form.errors %}
-      <h4>{% blocktrans count counter=form.errors|length %}{% trans "Please correct the error below" %}{% plural %}{% trans "Please correct the
-        errors below" %}{% endblocktrans %}</h4>
+      <h4>{% blocktrans count counter=form.errors|length %}Please correct the error below{% plural %}Please correct the
+        errors below{% endblocktrans %}</h4>
     {% endif %}
 
     {% if form.comment.errors %}{{ form.comment.errors }}{% endif %}

--- a/ndohyep/templates/comments/preview.html
+++ b/ndohyep/templates/comments/preview.html
@@ -21,7 +21,7 @@
       {% if request.user.is_authenticated %}
         {% include "comments/form.html" with node=comment %}
       {% else %}
-        <p>Please <a href="{% url 'molo.profiles:auth_login' %}">log in</a> to leave a comment.</p>
+        <p>{% trans "Please " %}<a href="{% url 'molo.profiles:auth_login' %}">{% trans "log in" %}</a>{% trans " to leave a comment." %}</p>
       {% endif %}
 		</div>
   </div>

--- a/ndohyep/templates/comments/reply.html
+++ b/ndohyep/templates/comments/reply.html
@@ -17,7 +17,7 @@
       {% if request.user.is_authenticated %}
         {% include "comments/form.html" with node=comment %}
       {% else %}
-        <p>Please <a href="{% url 'molo.profiles:auth_login' %}">log in</a> to leave a comment.</p>
+        <p>{% trans "Please " %}<a href="{% url 'molo.profiles:auth_login' %}">{% trans "log in" %}</a>{% trans " to leave a comment." %}</p>
       {% endif %}
 		</div>
   </div>

--- a/ndohyep/templates/comments/report_response.html
+++ b/ndohyep/templates/comments/report_response.html
@@ -1,0 +1,17 @@
+{% extends "core/_article_page.html" %}
+{% load wagtailcore_tags wagtailimages_tags comments mptt_tags molo_commenting_tags i18n %}
+
+{% block content %}
+<div class="block {{article.get_parent_section.get_effective_extra_style_hints}}">
+  <br>
+  <h4 class="left">{% trans "Thanks!" %}</h4>
+</div>
+<div class="block">
+  <br>
+  <p><strong>{% trans "This comment has been reported." %}</strong>
+  {% trans "It will be reviewed by the B-Wise team and may be removed if it breaks our Platform rules" %}</p>
+</div>
+<div class="title {{article.get_parent_section.get_effective_extra_style_hints}}">
+  <a href="javascript:history.back();" class="button">{% trans "Back" %}</a>
+</div>
+{% endblock %}

--- a/ndohyep/templates/core/article_page.html
+++ b/ndohyep/templates/core/article_page.html
@@ -62,9 +62,8 @@
 </div><!-- /block -->
 
 <div class="block {{self.articlepage.get_parent_section.get_effective_extra_style_hints}}">
-
   <div class="post-comment">
-    <a href="" class="comments-count">{{comment_count}}</a>
+    <a href="#comments-list" class="comments-count">{{comment_count}}</a>
     <h4>{% trans "Add a Comment/Question" %}</h4>
     {% if request.user.is_authenticated %}
     {% render_comment_form for self %}
@@ -73,15 +72,19 @@
     <a href="{% url 'auth_login' %}?next={% pageurl self %}"><button>{% trans "SIGN IN" %}</button></a>
     {% endif %}
   </div><!-- /post-comment -->
-
-
-  {% get_molo_comments for self as comment_list %}
-  {% for node in comment_list|slice:":5" %}
-    {% include "comments/comment.html" %}
-  {% endfor %}
-
-  <p class="back"><a href="javascript: history.go(-1)">&lt; {% trans "Back" %}</a></p>
+<div id="comments-list">
+  {% get_comment_count for self as comment_count %}
+    {% get_molo_comments for self as comment_list %}
+      {% for node in comment_list %}
+        {% include "comments/comment.html" %}
+      {% endfor %}
+  {% if comment_count > 5 %}
+    <div class="pagination">
+      <a href="{% url 'more-comments' self.pk %}">{% trans "View more comments" %}</a>
+    </div>
+  {% endif %}
+</div>
+  <p class="back">&lt; <a href="javascript: history.go(-1)">{% trans "Back" %}</a></p>
 
 </div><!-- /block -->
-
 {% endblock %}

--- a/ndohyep/urls.py
+++ b/ndohyep/urls.py
@@ -5,7 +5,7 @@ from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 
-from app.views import CommentReplyForm, search
+from app.views import CommentReplyForm, search, report_response
 
 
 urlpatterns = patterns(
@@ -20,6 +20,8 @@ urlpatterns = patterns(
     url(r'commenting/', include('molo.commenting.urls')),
     url(r'commenting/reply/(?P<parent_id>\d+)/$', CommentReplyForm.as_view(),
         name='comments-reply'),
+    url(r'^comments/reported/(?P<comment_pk>\d+)/$',
+        report_response, name='report_response'),
     url(r'search/$', search, name='search'),
     url(r'', include(wagtail_urls)),
     url(r'^djga/', include('google_analytics.urls')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-molo.core==2.4.2
-molo.commenting<1.0.0,>=0.2.3
+molo.core==2.5.0
+molo.commenting<1.0.0,>=0.2.5
 django-google-analytics-app
 django-celery
 elasticsearch


### PR DESCRIPTION
Each article that has more than the max number of comments should have a ‘View more comments’ at the bottom of the page that links to a paginated view of all comments.
